### PR TITLE
replace SdFat for SdFs in both PCAP.cpp and PCAP.h

### DIFF
--- a/src/PCAP.cpp
+++ b/src/PCAP.cpp
@@ -39,7 +39,7 @@ void PCAP::startSerial(){
 	}
 #else
 	/* open file on SD card (when exists) */
-	bool PCAP::openFile(SdFat &SD){
+	bool PCAP::openFile(SdFs &SD){
 	  if(SD.exists(filename.c_str())) removeFile(SD);
 	  file = SD.open(filename, FILE_WRITE);
 	  if(file) {
@@ -56,7 +56,7 @@ void PCAP::startSerial(){
 	}
 
 	/* remove file from SD card */
-	bool PCAP::removeFile(SdFat &SD){
+	bool PCAP::removeFile(SdFs &SD){
 	  return SD.remove(filename.c_str());
 	}
 #endif

--- a/src/PCAP.h
+++ b/src/PCAP.h
@@ -28,8 +28,8 @@ class PCAP
 	bool openFile(fs::FS &fs);
     bool removeFile(fs::FS &fs);
 #else
-	bool openFile(SdFat &SD);
-    bool removeFile(SdFat &SD);
+	bool openFile(SdFs &SD);
+    bool removeFile(SdFs &SD);
 #endif
 	
     void flushFile();
@@ -49,7 +49,7 @@ class PCAP
     uint32_t network = 105;
 
   private:
-    File file;
+    FsFile file;
 
     void escape32(uint32_t n, uint8_t* buf);
     void escape16(uint16_t n, uint8_t* buf);


### PR DESCRIPTION
This pull request is concerning [issue 15 (SdFat error)](https://github.com/spacehuhn/ArduinoPcap/issues/15)
This replaces all instances of SdFat for SdFs in PCAP.cpp and PCAP.h